### PR TITLE
Fixing shell scripts to run it outside of bin directory

### DIFF
--- a/deploy/bin/hdfs-shell-daemon.sh
+++ b/deploy/bin/hdfs-shell-daemon.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -Ddaemon=true -Xms200m -Xmx400m -cp ./lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"
+CWD=$(cd $(dirname $0); pwd)  
+
+java -Ddaemon=true -Xms200m -Xmx400m -cp ${CWD}/lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"

--- a/deploy/bin/hdfs-shell.sh
+++ b/deploy/bin/hdfs-shell.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -Xms200m -Xmx400m -cp ./lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"
+CWD=$(cd $(dirname $0); pwd)  
+
+java -Xms200m -Xmx400m -cp ${CWD}/lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"


### PR DESCRIPTION
Hi, 

First, thank you for a very convenient hdfs shell program!
It helps me a lot (especially, I love tab-completion :-)


While trying to use this program, I faced a small problem that I had to run hdfs-shell.sh inside bin directory.
This pull requests make hdfs-shell.sh and hdfs-shell-daemon.sh scripts run outside of bin directory by resolving the relative path to ./lib directory (for -cp option) from the current working directory.

Hope this patch helpful for other users.


Best wishes,
Han-cheol

