### PR TITLE
Make "Download binary" a proper markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are 3 possible usecases:
 - It's working on both Windows/Linux Hadoop 2.6.0
 
 #### Download
-- [Download binary] (https://github.com/avast/hdfs-shell/releases/download/v1.0.2/hdfs-shell-1.0.2.zip)
+- [Download binary](https://github.com/avast/hdfs-shell/releases/download/v1.0.2/hdfs-shell-1.0.2.zip)
 
 #### Configuring launch script(s) for your environment
 HDFS-Shell is a standard Java application. For its launch you need to define 2 things on your classpath:


### PR DESCRIPTION
This trivial documentation change removes the extraneous space in `[Download] (http://...)` to make it a proper link with text "Download binary".