### PR TITLE
Recognize correct SCRIPT_DIR with symlink

### DIFF
--- a/deploy/bin/hdfs-shell.sh
+++ b/deploy/bin/hdfs-shell.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )"
 HADOOP_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 
 echo "Launching HDFS Shell with HADOOP_CONF_DIR: ${HADOOP_DIR}"


### PR DESCRIPTION
The `hdfs-shell.sh` script will fail to find its home directory when it's symlinked to other locations through `ln -s`. Add `readlink` inside `dirname` command will get the expected behaviour.