### PR TITLE
Use gradle installDist to generate starter script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,3 +84,9 @@ dependencies {
     testCompile("org.springframework.boot:spring-boot-starter-test:1.4.2.RELEASE")
 }
 
+startScripts{
+    applicationName = 'hdfs-shell'
+    unixStartScriptGenerator.template = resources.text.fromFile('deploy/bin/hdfs_shell.unix.template.sh')
+    windowsStartScriptGenerator.template = resources.text.fromFile('deploy/bin/hdfs_shell.win.template.bat')
+}
+

--- a/deploy/bin/hdfs_shell.unix.template.sh
+++ b/deploy/bin/hdfs_shell.unix.template.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+SCRIPT_FULL_PATH="\$(readlink -f "\${BASH_SOURCE[0]}")"
+BIN_DIR="\$(dirname "\${SCRIPT_FULL_PATH}")"
+LIB_DIR="\$(readlink -f "\${BIN_DIR}/../lib")"
+HADOOP_DIR="\${HADOOP_CONF_DIR:-/etc/hadoop/conf}"
+HADOOP_CLASSPATH="\${HADOOP_CLASSPATH:-\$(hadoop classpath)}"
+command_args=(java -Xms200m -Xmx400m -cp "\${LIB_DIR}/*:\${HADOOP_DIR}:\${HADOOP_CLASSPATH}")
+echo "Launching HDFS Shell with HADOOP_CONF_DIR: \${HADOOP_DIR}"
+
+while (( \$# > 0 )); do
+  case "\$1" in
+    -d|--daemon) command_args+=('-Ddaemon=true'); shift;;
+  esac
+  shift
+done
+command_args+=( ${mainClassName} "\$@")
+command "\${command_args[@]}"

--- a/deploy/bin/hdfs_shell.win.template.bat
+++ b/deploy/bin/hdfs_shell.win.template.bat
@@ -1,0 +1,12 @@
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%..
+set LIB_DIR=%APP_HOME%/lib
+
+echo Launching HDFS Shell with HADOOP_CONF_DIR: %HADOOP_DIR%
+java.exe -Xms200m -Xmx400m -cp "%LIB_DIR%/*:%HADOOP_DIR%:%HADOOP_CLASSPATH%" ${mainClassName} %CMD_LINE_ARGS%
+if "%OS%"=="Windows_NT" endlocal


### PR DESCRIPTION
Dear,
 
this pull request allow gradle to generate starter script using the command

```bash
$ gradle installDist
```

Note:

1. The windows starter script is untested
2. The hdfs-shell script can be run as deamon by providing the flag `-d` or `--daemon`

